### PR TITLE
Remove trailing comma from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,5 @@
   "bugs": {
     "url": "https://github.com/bbc/gel-grid.css/issues"
   },
-  "homepage": "http://www.bbc.co.uk/gel",
+  "homepage": "http://www.bbc.co.uk/gel"
 }


### PR DESCRIPTION
This commit removes a trailing comma which was preventing the package being installed via npm.